### PR TITLE
fix: actually fail if an import fails

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -62,7 +62,9 @@ export default async function runTests(tests) {
 
   if (!failures) {
     setStatus(`All ${tests.length} tests passed.`);
+    return true;
   } else {
     setStatus(`${failures} tests failed.`);
+    return false;
   }
 }

--- a/src/test-harness.js
+++ b/src/test-harness.js
@@ -7,7 +7,7 @@ if (!id) {
 }
 
 const tests = await (await fetch(`/data?id=${id}`)).json();
-await runTests(
+const passed = await runTests(
   tests.map((test) => {
     return {
       test: test.imports,
@@ -21,4 +21,8 @@ await runTests(
   })
 );
 
-fetch(`/done?id=${id}`);
+if (passed) {
+  fetch(`/done?id=${id}`);
+} else {
+  fetch(`/error?id=${id}&msg=failure`);
+}


### PR DESCRIPTION
One of the tests is actually failing, but CI passes anyway because I forgot to
wire up the error handler. Whoops. Also why the `@babel/core` build is passing
in the cdn despite not building `chalk` correctly.
